### PR TITLE
:coffin: Delete inportation of library ```dplyr```

### DIFF
--- a/prueba1_ENOE.R
+++ b/prueba1_ENOE.R
@@ -1,7 +1,6 @@
 getwd()
 setwd("C:/Users/Francisco/OneDrive - Instituto Tecnologico y de Estudios Superiores de Monterrey/Doctorado - COLSON/Semestre 2/EACS/Prácticas R/Resultados preliminares")
 
-library(dplyr)
 library(survey)
 library(foreign)
 library(tidyverse)


### PR DESCRIPTION
Library ```dplyr``` is loaded with ```library(tidyverse)```.